### PR TITLE
feat(repository): add snapshot JSON file I/O utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ scripts/sample-data/
 # VitePress build outputs
 docs/.vitepress/cache
 docs/.vitepress/dist
+
+# Local test fixtures
+test/__local_fixtures__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **リポジトリ**: スナップショットの JSON ファイル I/O ユーティリティを追加 (#8)
+    - `exportSnapshotToFile()` / `importSnapshotFromFile()` を `promidas-utils/repository` から公開
+    - ディレクトリの自動作成、一時ファイルを介したアトミックな書き込み、判別可能なエラー型 (`FileIoError`) を提供
+    - import 失敗が promidas の検証由来の場合は `SnapshotOperationFailure` を保持し、既存の `toLocalizedMessage()` で日本語化可能
+
 ## [3.0.0] - 2026-01-28
 
 ### Breaking

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -128,12 +128,15 @@ git push origin vx.y.z
 5. Copy the relevant version content from CHANGELOG.md
 6. Click "Publish release"
 
-**Automated Publishing:** When the release is published, the [GitHub Actions workflow](.github/workflows/publish-package-to-github-packages.yml) automatically:
+**Automated Publishing:** When the release is published, the [GitHub Actions workflow](.github/workflows/publish-package-to-npmjs.yml) automatically:
 
 1. Builds the package (`npm run build`)
-2. Publishes to GitHub Packages (`npm publish`)
+2. Publishes to [npmjs](https://www.npmjs.com/package/promidas-utils) using [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC, no npm token required) with provenance (`npm publish --provenance`)
 
 No manual `npm publish` is required.
+
+> Trusted Publishing requires npm 11.5.1 or later, which the workflow provisions.
+> The legacy `publish-package-to-github-packages.yml` workflow is disabled.
 
 ## Troubleshooting
 
@@ -144,7 +147,7 @@ If the GitHub Actions workflow fails:
 1. Check the workflow run logs in the "Actions" tab
 2. Verify `package.json` version matches the release tag
 3. Ensure all CI checks passed before creating the release
-4. Check GitHub Packages permissions
+4. Verify the Trusted Publishing configuration on npmjs (the package's trusted publisher must reference this repository and the `publish-package-to-npmjs.yml` workflow)
 
 ### Tag Already Exists
 

--- a/docs/api/repository.md
+++ b/docs/api/repository.md
@@ -19,6 +19,9 @@ instructions-for-ais:
 
 - 型: `ParsedSnapshotOperationFailure`
 - 関数: `parseSnapshotOperationFailure`, `toLocalizedMessage`
+- スナップショットファイル I/O (Node.js):
+    - 関数: `exportSnapshotToFile`, `importSnapshotFromFile`
+    - 型: `FileExportResult`, `FileExportSuccess`, `FileExportFailure`, `FileImportResult`, `FileImportSuccess`, `FileImportFailure`, `FileIoError`, `FileIoErrorKind`, `ExportSnapshotOptions`
 
 > ルートパス `promidas-utils` からの再エクスポートはありません。必ず上記パスを利用してください。
 
@@ -46,7 +49,7 @@ type ParsedSnapshotOperationFailure = SnapshotOperationFailure & {
 - エラーの発生元 (fetcher, store, repository, unknown) に応じて適切な日本語メッセージを生成します
 - 元のエラーオブジェクトの全てのプロパティを保持します
 
-#### 使用例
+#### 使用例: parseSnapshotOperationFailure
 
 ```typescript
 import { parseSnapshotOperationFailure } from 'promidas-utils/repository';
@@ -70,7 +73,7 @@ if (!result.ok) {
 - エラーの発生元に応じて適切な日本語メッセージを生成します
 - オブジェクトの作成を避け、メッセージのみが必要な場合に効率的です
 
-#### 使用例
+#### 使用例: toLocalizedMessage
 
 ```typescript
 import { toLocalizedMessage } from 'promidas-utils/repository';
@@ -82,6 +85,90 @@ if (!result.ok) {
     alert(message);
 }
 ```
+
+## スナップショットファイル I/O (Node.js)
+
+`promidas` の `getSerializableSnapshot()` / `setupSnapshotFromSerializedData()` を利用し、スナップショットを JSON ファイルとして永続化・復元する Node.js 向けユーティリティです。ディレクトリの自動作成、一時ファイルを介したアトミックな書き込み、判別可能なエラー分類を提供します。
+
+いずれの関数も例外を送出せず、結果は必ず判別可能ユニオン (`ok: true | false`) で返します。
+
+以降の使用例に登場する `repository` は、`promidas` のファクトリで生成した `ProtopediaInMemoryRepository` です。生成方法の詳細は [promidas のファクトリ](https://f88.github.io/promidas/features/factory.html) を参照してください。
+
+```typescript
+import { createPromidasForLocal } from 'promidas';
+
+const repository = createPromidasForLocal({
+    protopediaApiToken: 'your-api-token',
+});
+```
+
+> `exportSnapshotToFile` はスナップショットが読み込み済みのリポジトリを前提とします (例: 先に `repository.setupSnapshot()` で ProtoPedia API から取得しておく)。一方 `importSnapshotFromFile` はファイルから復元するため、事前の API アクセスは不要です (トークンの値も利用されません)。
+
+### `exportSnapshotToFile(repository, filePath, options?): Promise<FileExportResult>`
+
+リポジトリのスナップショットを JSON ファイルへ書き出します。
+
+- `repository`: `getSerializableSnapshot()` を持つオブジェクト (`Pick` で受けるため完全な `ProtopediaInMemoryRepository` も渡せます)
+- `filePath`: 出力先パス。存在しない親ディレクトリは自動作成されます
+- `options.pretty`: `true` で 2 スペース整形。既定は `false` (コンパクト)
+- 書き込みは一意な一時ファイル (`<filePath>.<uuid>.tmp`) へ行い、成功時に `rename` で確定します
+
+#### 使用例: exportSnapshotToFile
+
+```typescript
+import { exportSnapshotToFile } from 'promidas-utils/repository';
+
+// repository には取得済みのスナップショットがある前提 (例: await repository.setupSnapshot())
+const result = await exportSnapshotToFile(repository, './data/snapshot.json', {
+    pretty: true,
+});
+
+if (result.ok) {
+    console.log(
+        `Exported ${result.prototypesExported} prototypes (${result.bytesWritten} bytes)`,
+    );
+} else {
+    console.error(`${result.error.kind}: ${result.error.message}`);
+}
+```
+
+### `importSnapshotFromFile(repository, filePath): Promise<FileImportResult>`
+
+JSON ファイルからスナップショットを読み込み、リポジトリへ復元します。
+
+- `repository`: `setupSnapshotFromSerializedData()` を持つオブジェクト
+- `filePath`: 読み込むファイルパス
+- データ構造の検証は `promidas` 側が担います。検証に失敗した場合は `error.snapshotFailure` に元の `SnapshotOperationFailure` を保持するため、`toLocalizedMessage(error.snapshotFailure)` で日本語化できます
+
+#### 使用例: importSnapshotFromFile
+
+```typescript
+import {
+    importSnapshotFromFile,
+    toLocalizedMessage,
+} from 'promidas-utils/repository';
+
+// ファイルから復元するため API アクセスは不要
+const result = await importSnapshotFromFile(repository, './data/snapshot.json');
+
+if (result.ok) {
+    console.log(`Loaded ${result.prototypesLoaded} prototypes`);
+} else if (result.error.kind === 'SETUP_FAILED') {
+    console.error(toLocalizedMessage(result.error.snapshotFailure ?? null));
+} else {
+    console.error(`${result.error.kind}: ${result.error.message}`);
+}
+```
+
+### エラー種別 (`FileIoErrorKind`)
+
+`FileIoError.kind` は失敗した段階を表します。`FileIoError.code` には Node.js のファイルシステムエラーコード (`ENOENT`, `EACCES`, `ENOSPC` など) が入る場合があり、`FileIoError.cause` に元の例外を保持します。
+
+- `SERIALIZE_FAILED`: `getSerializableSnapshot()` または `JSON.stringify()` が失敗
+- `WRITE_FAILED`: `mkdir` / `writeFile` / `rename` が失敗
+- `READ_FAILED`: `readFile` が失敗 (`ENOENT` を含む)
+- `PARSE_FAILED`: `JSON.parse()` が失敗
+- `SETUP_FAILED`: `setupSnapshotFromSerializedData()` が `{ ok: false }` を返した
 
 ## エラーメッセージの種類
 

--- a/lib/repository/index.ts
+++ b/lib/repository/index.ts
@@ -12,3 +12,20 @@ export {
   toLocalizedMessage,
   type ParsedSnapshotOperationFailure,
 } from './snapshot-operation-failure-utils.js';
+
+export {
+  exportSnapshotToFile,
+  importSnapshotFromFile,
+} from './snapshot-file-io.js';
+
+export type {
+  ExportSnapshotOptions,
+  FileExportFailure,
+  FileExportResult,
+  FileExportSuccess,
+  FileImportFailure,
+  FileImportResult,
+  FileImportSuccess,
+  FileIoError,
+  FileIoErrorKind,
+} from './types.js';

--- a/lib/repository/snapshot-file-io.ts
+++ b/lib/repository/snapshot-file-io.ts
@@ -1,0 +1,205 @@
+/**
+ * Node.js file I/O utilities for PROMIDAS repository snapshots.
+ *
+ * PROMIDAS provides platform-agnostic serialization
+ * (`getSerializableSnapshot()` / `setupSnapshotFromSerializedData()`) but leaves
+ * the actual file I/O to the caller. This module supplies thin Node.js wrappers
+ * that add error classification, atomic writes, and automatic directory creation.
+ *
+ * @packageDocumentation
+ */
+
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import type { ProtopediaInMemoryRepository } from 'promidas/repository';
+import type { SerializableSnapshot } from 'promidas/repository/types';
+
+import type {
+  ExportSnapshotOptions,
+  FileExportResult,
+  FileImportResult,
+} from './types.js';
+
+/**
+ * Normalizes an unknown thrown value into a human-readable message.
+ *
+ * @param error - The value thrown by a `try` block.
+ * @returns The error's message, or its `String()` form when it is not an `Error`.
+ */
+function toMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Builds a `{ code }` fragment from a filesystem error, omitting the property
+ * entirely when no code is available (required by `exactOptionalPropertyTypes`).
+ *
+ * @param error - The value thrown by a filesystem operation.
+ * @returns An object with `code` when present, otherwise an empty object.
+ */
+function errorCodeFragment(error: unknown): { code?: string } {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  /* c8 ignore start -- filesystem errors always carry a code; defensive guard */
+  if (code === undefined) {
+    return {};
+  }
+  /* c8 ignore stop */
+  return { code };
+}
+
+/**
+ * Exports a repository's snapshot to a JSON file.
+ *
+ * The snapshot is obtained via `repository.getSerializableSnapshot()`, serialized
+ * to JSON, and written atomically: it is first written to a unique temporary file
+ * in the same directory and then renamed onto {@link filePath}. Missing parent
+ * directories are created automatically. This function never throws; all failures
+ * are returned as a {@link FileExportResult} with `ok: false`.
+ *
+ * @param repository - A repository exposing `getSerializableSnapshot()`.
+ * @param filePath - Destination path for the JSON file.
+ * @param options - Optional serialization options (e.g. `pretty`).
+ * @returns The export result, discriminated by `ok`.
+ *
+ * @example
+ * ```typescript
+ * const result = await exportSnapshotToFile(repository, './data/snapshot.json', {
+ *   pretty: true,
+ * });
+ * if (result.ok) {
+ *   console.log(`Wrote ${result.prototypesExported} prototypes`);
+ * }
+ * ```
+ */
+export async function exportSnapshotToFile(
+  repository: Pick<ProtopediaInMemoryRepository, 'getSerializableSnapshot'>,
+  filePath: string,
+  options?: ExportSnapshotOptions,
+): Promise<FileExportResult> {
+  let json: string;
+  let prototypesExported: number;
+  try {
+    const snapshot = repository.getSerializableSnapshot();
+    prototypesExported = snapshot.prototypes.length;
+    json = JSON.stringify(snapshot, null, options?.pretty ? 2 : undefined);
+  } catch (error) {
+    return {
+      ok: false,
+      filePath,
+      error: {
+        kind: 'SERIALIZE_FAILED',
+        message: toMessage(error),
+        cause: error,
+      },
+    };
+  }
+
+  const bytesWritten = Buffer.byteLength(json, 'utf8');
+  const tempPath = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(tempPath, json, 'utf8');
+    await rename(tempPath, filePath);
+  } catch (error) {
+    // Best-effort cleanup of the temporary file; ignore removal errors.
+    await rm(tempPath, { force: true }).catch(() => {});
+    return {
+      ok: false,
+      filePath,
+      error: {
+        kind: 'WRITE_FAILED',
+        message: toMessage(error),
+        ...errorCodeFragment(error),
+        cause: error,
+      },
+    };
+  }
+
+  return { ok: true, filePath, bytesWritten, prototypesExported };
+}
+
+/**
+ * Imports a snapshot from a JSON file into a repository.
+ *
+ * The file is read, parsed as JSON, and passed to
+ * `repository.setupSnapshotFromSerializedData()`, which validates the data. This
+ * function never throws; all failures are returned as a {@link FileImportResult}
+ * with `ok: false`. When PROMIDAS rejects the data, the original failure is
+ * preserved in `error.snapshotFailure` so callers may localize it via
+ * `toLocalizedMessage()`.
+ *
+ * @param repository - A repository exposing `setupSnapshotFromSerializedData()`.
+ * @param filePath - Path of the JSON file to import.
+ * @returns The import result, discriminated by `ok`.
+ *
+ * @example
+ * ```typescript
+ * const result = await importSnapshotFromFile(repository, './data/snapshot.json');
+ * if (result.ok) {
+ *   console.log(`Loaded ${result.prototypesLoaded} prototypes`);
+ * }
+ * ```
+ */
+export async function importSnapshotFromFile(
+  repository: Pick<
+    ProtopediaInMemoryRepository,
+    'setupSnapshotFromSerializedData'
+  >,
+  filePath: string,
+): Promise<FileImportResult> {
+  let content: string;
+  try {
+    content = await readFile(filePath, 'utf8');
+  } catch (error) {
+    return {
+      ok: false,
+      filePath,
+      error: {
+        kind: 'READ_FAILED',
+        message: toMessage(error),
+        ...errorCodeFragment(error),
+        cause: error,
+      },
+    };
+  }
+
+  const bytesRead = Buffer.byteLength(content, 'utf8');
+
+  let data: SerializableSnapshot;
+  try {
+    // Structural validation is delegated to PROMIDAS' validateSerializableSnapshot.
+    data = JSON.parse(content) as SerializableSnapshot;
+  } catch (error) {
+    return {
+      ok: false,
+      filePath,
+      error: {
+        kind: 'PARSE_FAILED',
+        message: toMessage(error),
+        cause: error,
+      },
+    };
+  }
+
+  const result = repository.setupSnapshotFromSerializedData(data);
+  if (!result.ok) {
+    return {
+      ok: false,
+      filePath,
+      error: {
+        kind: 'SETUP_FAILED',
+        message: result.message,
+        snapshotFailure: result,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    filePath,
+    bytesRead,
+    prototypesLoaded: result.stats.size,
+  };
+}

--- a/lib/repository/snapshot-file-io.ts
+++ b/lib/repository/snapshot-file-io.ts
@@ -14,7 +14,10 @@ import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import type { ProtopediaInMemoryRepository } from 'promidas/repository';
-import type { SerializableSnapshot } from 'promidas/repository/types';
+import type {
+  SerializableSnapshot,
+  SnapshotOperationResult,
+} from 'promidas/repository/types';
 
 import type {
   ExportSnapshotOptions,
@@ -183,7 +186,24 @@ export async function importSnapshotFromFile(
     };
   }
 
-  const result = repository.setupSnapshotFromSerializedData(data);
+  // `repository` may be any object satisfying the Pick type, so guard the call
+  // to uphold this function's "never throws" contract even if a custom
+  // implementation throws. PROMIDAS' own repository is documented never to throw.
+  let result: SnapshotOperationResult;
+  try {
+    result = repository.setupSnapshotFromSerializedData(data);
+  } catch (error) {
+    return {
+      ok: false,
+      filePath,
+      error: {
+        kind: 'SETUP_FAILED',
+        message: toMessage(error),
+        cause: error,
+      },
+    };
+  }
+
   if (!result.ok) {
     return {
       ok: false,

--- a/lib/repository/types.ts
+++ b/lib/repository/types.ts
@@ -1,0 +1,116 @@
+/**
+ * @fileoverview Type definitions for repository snapshot file I/O.
+ * @module lib/repository/types
+ */
+
+import type { SnapshotOperationFailure } from 'promidas/repository/types';
+
+/**
+ * Discriminates the stage at which a file I/O operation failed.
+ *
+ * @remarks
+ * Node.js filesystem errors cannot be reliably distinguished across platforms,
+ * so specific causes (permission denied, disk full, etc.) are not enumerated as
+ * separate kinds. Inspect {@link FileIoError.code} for the underlying Node error
+ * code (e.g. `'EACCES'`, `'ENOSPC'`) when finer classification is required.
+ *
+ * - `'SERIALIZE_FAILED'`: `getSerializableSnapshot()` or `JSON.stringify()` threw.
+ * - `'WRITE_FAILED'`: `mkdir`/`writeFile`/`rename` threw during export.
+ * - `'READ_FAILED'`: `readFile` threw during import (includes `ENOENT`).
+ * - `'PARSE_FAILED'`: `JSON.parse()` threw during import.
+ * - `'SETUP_FAILED'`: `setupSnapshotFromSerializedData()` returned `{ ok: false }`.
+ */
+export type FileIoErrorKind =
+  | 'SERIALIZE_FAILED'
+  | 'WRITE_FAILED'
+  | 'READ_FAILED'
+  | 'PARSE_FAILED'
+  | 'SETUP_FAILED';
+
+/**
+ * Describes why a snapshot file I/O operation failed.
+ *
+ * @remarks
+ * When `kind` is `'SETUP_FAILED'`, {@link FileIoError.snapshotFailure} holds the
+ * original PROMIDAS failure, which can be passed to `toLocalizedMessage()` from
+ * {@link module:lib/repository/snapshot-operation-failure-utils} for a localized
+ * (Japanese) message.
+ */
+export type FileIoError = {
+  /** Stage at which the operation failed. */
+  readonly kind: FileIoErrorKind;
+  /** Human-readable description of the failure. */
+  readonly message: string;
+  /** Node.js filesystem error code when available (e.g. `'ENOENT'`, `'EACCES'`). */
+  readonly code?: string;
+  /** The original thrown value, preserved for debugging. */
+  readonly cause?: unknown;
+  /** The underlying PROMIDAS failure. Present only when `kind` is `'SETUP_FAILED'`. */
+  readonly snapshotFailure?: SnapshotOperationFailure;
+};
+
+/**
+ * Result of a successful {@link module:lib/repository/snapshot-file-io.exportSnapshotToFile}.
+ */
+export type FileExportSuccess = {
+  readonly ok: true;
+  /** The path the snapshot was written to. */
+  readonly filePath: string;
+  /** Number of bytes written (UTF-8 byte length of the JSON). */
+  readonly bytesWritten: number;
+  /** Number of prototypes contained in the exported snapshot. */
+  readonly prototypesExported: number;
+};
+
+/**
+ * Result of a failed {@link module:lib/repository/snapshot-file-io.exportSnapshotToFile}.
+ */
+export type FileExportFailure = {
+  readonly ok: false;
+  /** The target path of the export attempt. */
+  readonly filePath: string;
+  /** Details of the failure. */
+  readonly error: FileIoError;
+};
+
+/**
+ * Discriminated union result of `exportSnapshotToFile`.
+ */
+export type FileExportResult = FileExportSuccess | FileExportFailure;
+
+/**
+ * Result of a successful {@link module:lib/repository/snapshot-file-io.importSnapshotFromFile}.
+ */
+export type FileImportSuccess = {
+  readonly ok: true;
+  /** The path the snapshot was read from. */
+  readonly filePath: string;
+  /** Number of bytes read (UTF-8 byte length of the file contents). */
+  readonly bytesRead: number;
+  /** Number of prototypes loaded into the repository. */
+  readonly prototypesLoaded: number;
+};
+
+/**
+ * Result of a failed {@link module:lib/repository/snapshot-file-io.importSnapshotFromFile}.
+ */
+export type FileImportFailure = {
+  readonly ok: false;
+  /** The source path of the import attempt. */
+  readonly filePath: string;
+  /** Details of the failure. */
+  readonly error: FileIoError;
+};
+
+/**
+ * Discriminated union result of `importSnapshotFromFile`.
+ */
+export type FileImportResult = FileImportSuccess | FileImportFailure;
+
+/**
+ * Options for {@link module:lib/repository/snapshot-file-io.exportSnapshotToFile}.
+ */
+export type ExportSnapshotOptions = {
+  /** Pretty-print the JSON with 2-space indentation. Defaults to `false` (compact). */
+  readonly pretty?: boolean;
+};

--- a/test/helpers/create-normalized-prototype.ts
+++ b/test/helpers/create-normalized-prototype.ts
@@ -1,0 +1,33 @@
+import type { NormalizedPrototype } from 'promidas/types';
+
+/**
+ * Creates a minimal, schema-valid NormalizedPrototype for tests.
+ *
+ * Only the fields required by PROMIDAS' normalizedPrototypeSchema are populated;
+ * optional fields are omitted. Pass `overrides` to customize specific fields.
+ */
+export function createNormalizedPrototype(
+  overrides: Partial<NormalizedPrototype> = {},
+): NormalizedPrototype {
+  return {
+    id: 1,
+    createDate: '2026-01-01T00:00:00.000Z',
+    releaseFlg: 2,
+    status: 3,
+    prototypeNm: 'Test Prototype',
+    summary: '',
+    freeComment: '',
+    systemDescription: '',
+    users: [],
+    teamNm: '',
+    tags: [],
+    materials: [],
+    events: [],
+    awards: [],
+    mainUrl: '',
+    viewCount: 0,
+    goodCount: 0,
+    commentCount: 0,
+    ...overrides,
+  };
+}

--- a/test/repository/snapshot-file-io.test.ts
+++ b/test/repository/snapshot-file-io.test.ts
@@ -1,0 +1,339 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createPromidasForLocal } from 'promidas';
+import type {
+  RepositorySnapshotFailure,
+  SerializableSnapshot,
+  SnapshotOperationResult,
+} from 'promidas/repository/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  exportSnapshotToFile,
+  importSnapshotFromFile,
+} from '../../lib/repository/snapshot-file-io.js';
+import { toLocalizedMessage } from '../../lib/repository/snapshot-operation-failure-utils.js';
+import { createNormalizedPrototype } from '../helpers/create-normalized-prototype.js';
+import { createPrototypeInMemoryStats } from '../helpers/create-prototype-In-memory-stats.js';
+
+/** Builds a schema-valid snapshot with `count` distinct prototypes. */
+function makeValidSnapshot(count: number): SerializableSnapshot {
+  return {
+    version: '1.0.0',
+    serializedAt: '2026-01-01T00:00:00.000Z',
+    prototypes: Array.from({ length: count }, (_, index) =>
+      createNormalizedPrototype({
+        id: index + 1,
+        prototypeNm: `Prototype ${index + 1}`,
+      }),
+    ),
+  };
+}
+
+/**
+ * Builds a minimal SerializableSnapshot with `count` placeholder prototypes.
+ * The prototype shape is irrelevant here: export only reads `prototypes.length`
+ * and serializes to JSON, and the import stub does not validate structure.
+ */
+function makeSnapshot(count: number): SerializableSnapshot {
+  const prototypes = Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+  }));
+  return {
+    version: '1.0.0',
+    serializedAt: '2026-01-01T00:00:00.000Z',
+    prototypes,
+  } as unknown as SerializableSnapshot;
+}
+
+/** Stub repository exposing only `getSerializableSnapshot`. */
+function exportStub(snapshot: SerializableSnapshot) {
+  return { getSerializableSnapshot: vi.fn(() => snapshot) };
+}
+
+/** Stub repository exposing only `setupSnapshotFromSerializedData`. */
+function importStub(result: SnapshotOperationResult) {
+  return {
+    setupSnapshotFromSerializedData: vi.fn(
+      (_data: SerializableSnapshot) => result,
+    ),
+  };
+}
+
+describe('snapshot-file-io', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'promidas-snap-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  describe('exportSnapshotToFile', () => {
+    it('writes the snapshot and reports metadata', async () => {
+      const filePath = join(dir, 'snapshot.json');
+      const result = await exportSnapshotToFile(
+        exportStub(makeSnapshot(3)),
+        filePath,
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.filePath).toBe(filePath);
+      expect(result.prototypesExported).toBe(3);
+      expect(result.bytesWritten).toBeGreaterThan(0);
+
+      const written = await readFile(filePath, 'utf8');
+      expect(JSON.parse(written).prototypes).toHaveLength(3);
+    });
+
+    it('produces compact JSON by default and pretty JSON on request', async () => {
+      const compactPath = join(dir, 'compact.json');
+      const prettyPath = join(dir, 'pretty.json');
+
+      await exportSnapshotToFile(exportStub(makeSnapshot(1)), compactPath);
+      await exportSnapshotToFile(exportStub(makeSnapshot(1)), prettyPath, {
+        pretty: true,
+      });
+
+      const compact = await readFile(compactPath, 'utf8');
+      const pretty = await readFile(prettyPath, 'utf8');
+      expect(compact).not.toContain('\n');
+      expect(pretty).toContain('\n');
+      expect(pretty).toContain('  ');
+    });
+
+    it('creates missing parent directories', async () => {
+      const filePath = join(dir, 'a', 'b', 'c', 'snapshot.json');
+      const result = await exportSnapshotToFile(
+        exportStub(makeSnapshot(1)),
+        filePath,
+      );
+
+      expect(result.ok).toBe(true);
+      await expect(readFile(filePath, 'utf8')).resolves.toContain('version');
+    });
+
+    it('overwrites an existing file', async () => {
+      const filePath = join(dir, 'snapshot.json');
+      await exportSnapshotToFile(exportStub(makeSnapshot(1)), filePath);
+      await exportSnapshotToFile(exportStub(makeSnapshot(5)), filePath);
+
+      const written = await readFile(filePath, 'utf8');
+      expect(JSON.parse(written).prototypes).toHaveLength(5);
+    });
+
+    it('leaves no temporary file behind on success', async () => {
+      const filePath = join(dir, 'snapshot.json');
+      await exportSnapshotToFile(exportStub(makeSnapshot(1)), filePath);
+
+      const entries = await readdir(dir);
+      expect(entries).toEqual(['snapshot.json']);
+    });
+
+    it('returns SERIALIZE_FAILED when getSerializableSnapshot throws', async () => {
+      const repository = {
+        getSerializableSnapshot: vi.fn(() => {
+          throw new Error('boom');
+        }),
+      };
+      const filePath = join(dir, 'snapshot.json');
+      const result = await exportSnapshotToFile(repository, filePath);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe('SERIALIZE_FAILED');
+      expect(result.error.message).toBe('boom');
+      expect(result.error.cause).toBeInstanceOf(Error);
+    });
+
+    it('stringifies non-Error throwables in SERIALIZE_FAILED', async () => {
+      const repository = {
+        getSerializableSnapshot: vi.fn(() => {
+          throw 'plain failure';
+        }),
+      };
+      const result = await exportSnapshotToFile(
+        repository,
+        join(dir, 's.json'),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe('SERIALIZE_FAILED');
+      expect(result.error.message).toBe('plain failure');
+    });
+
+    it('returns WRITE_FAILED with a code when the path is unwritable', async () => {
+      // Make a regular file, then try to write beneath it so mkdir fails.
+      const blocker = join(dir, 'blocker');
+      await writeFile(blocker, 'x', 'utf8');
+      const filePath = join(blocker, 'snapshot.json');
+
+      const result = await exportSnapshotToFile(
+        exportStub(makeSnapshot(1)),
+        filePath,
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe('WRITE_FAILED');
+      expect(result.error.code).toBeDefined();
+
+      const entries = await readdir(dir);
+      expect(entries).toEqual(['blocker']);
+    });
+  });
+
+  describe('importSnapshotFromFile', () => {
+    it('loads a snapshot and reports metadata', async () => {
+      const filePath = join(dir, 'snapshot.json');
+      await writeFile(filePath, JSON.stringify(makeSnapshot(4)), 'utf8');
+
+      const repository = importStub({
+        ok: true,
+        stats: createPrototypeInMemoryStats({ size: 4 }),
+      });
+      const result = await importSnapshotFromFile(repository, filePath);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.filePath).toBe(filePath);
+      expect(result.prototypesLoaded).toBe(4);
+      expect(result.bytesRead).toBeGreaterThan(0);
+      expect(repository.setupSnapshotFromSerializedData).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    it('returns READ_FAILED with ENOENT for a missing file', async () => {
+      const result = await importSnapshotFromFile(
+        importStub({ ok: true, stats: createPrototypeInMemoryStats() }),
+        join(dir, 'missing.json'),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe('READ_FAILED');
+      expect(result.error.code).toBe('ENOENT');
+    });
+
+    it('returns PARSE_FAILED for malformed JSON', async () => {
+      const filePath = join(dir, 'broken.json');
+      await writeFile(filePath, '{ not valid json', 'utf8');
+
+      const result = await importSnapshotFromFile(
+        importStub({ ok: true, stats: createPrototypeInMemoryStats() }),
+        filePath,
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe('PARSE_FAILED');
+    });
+
+    it('returns SETUP_FAILED and preserves the localizable failure', async () => {
+      const filePath = join(dir, 'snapshot.json');
+      await writeFile(filePath, JSON.stringify(makeSnapshot(1)), 'utf8');
+
+      const failure: RepositorySnapshotFailure = {
+        ok: false,
+        origin: 'repository',
+        kind: 'validation',
+        code: 'REPOSITORY_VALIDATION_ERROR',
+        message: 'invalid snapshot',
+      };
+      const result = await importSnapshotFromFile(
+        importStub(failure),
+        filePath,
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe('SETUP_FAILED');
+      expect(result.error.snapshotFailure).toBe(failure);
+      expect(
+        toLocalizedMessage(result.error.snapshotFailure ?? null),
+      ).toContain('データの検証に失敗しました');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('exports then imports the same JSON file', async () => {
+      const filePath = join(dir, 'snapshot.json');
+      const snapshot = makeSnapshot(2);
+
+      const exportResult = await exportSnapshotToFile(
+        exportStub(snapshot),
+        filePath,
+      );
+      expect(exportResult.ok).toBe(true);
+
+      const repository = importStub({
+        ok: true,
+        stats: createPrototypeInMemoryStats({ size: 2 }),
+      });
+      const importResult = await importSnapshotFromFile(repository, filePath);
+
+      expect(importResult.ok).toBe(true);
+      expect(repository.setupSnapshotFromSerializedData).toHaveBeenCalledWith(
+        snapshot,
+      );
+    });
+  });
+
+  describe('integration with a real repository', () => {
+    it('starts empty, then reflects imported data in stats and reads', async () => {
+      const repository = createPromidasForLocal({
+        protopediaApiToken: 'dummy-token',
+        logLevel: 'warn',
+      });
+
+      // Before import: a freshly created repository holds no prototypes.
+      expect(repository.getStats().size).toBe(0);
+
+      const filePath = join(dir, 'valid.json');
+      await writeFile(filePath, JSON.stringify(makeValidSnapshot(3)), 'utf8');
+
+      const result = await importSnapshotFromFile(repository, filePath);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.prototypesLoaded).toBe(3);
+
+      // After import: the count changes and the data is queryable.
+      expect(repository.getStats().size).toBe(3);
+      const random = await repository.getRandomPrototypeFromSnapshot();
+      expect(random).not.toBeNull();
+      expect([1, 2, 3]).toContain(random?.id);
+    });
+
+    it('round-trips real data through export and re-import', async () => {
+      const source = createPromidasForLocal({
+        protopediaApiToken: 'dummy-token',
+        logLevel: 'warn',
+      });
+      const seedPath = join(dir, 'seed.json');
+      await writeFile(seedPath, JSON.stringify(makeValidSnapshot(2)), 'utf8');
+      await importSnapshotFromFile(source, seedPath);
+
+      const exportPath = join(dir, 'exported.json');
+      const exportResult = await exportSnapshotToFile(source, exportPath);
+      expect(exportResult.ok).toBe(true);
+
+      const target = createPromidasForLocal({
+        protopediaApiToken: 'dummy-token',
+        logLevel: 'warn',
+      });
+      const importResult = await importSnapshotFromFile(target, exportPath);
+
+      expect(importResult.ok).toBe(true);
+      if (!importResult.ok) return;
+      expect(importResult.prototypesLoaded).toBe(2);
+      expect(target.getStats().size).toBe(2);
+    });
+  });
+});

--- a/test/repository/snapshot-file-io.test.ts
+++ b/test/repository/snapshot-file-io.test.ts
@@ -260,6 +260,25 @@ describe('snapshot-file-io', () => {
         toLocalizedMessage(result.error.snapshotFailure ?? null),
       ).toContain('データの検証に失敗しました');
     });
+
+    it('returns SETUP_FAILED when the repository method throws', async () => {
+      const filePath = join(dir, 'snapshot.json');
+      await writeFile(filePath, JSON.stringify(makeSnapshot(1)), 'utf8');
+
+      const repository = {
+        setupSnapshotFromSerializedData: vi.fn(() => {
+          throw new Error('unexpected repository failure');
+        }),
+      };
+      const result = await importSnapshotFromFile(repository, filePath);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe('SETUP_FAILED');
+      expect(result.error.message).toBe('unexpected repository failure');
+      expect(result.error.cause).toBeInstanceOf(Error);
+      expect(result.error.snapshotFailure).toBeUndefined();
+    });
   });
 
   describe('round-trip', () => {


### PR DESCRIPTION
## 概要

Node.js 環境向けに、リポジトリのスナップショットを JSON ファイルとして永続化・復元するユーティリティを追加します (Issue #8)。

promidas 3.0.0 のプラットフォーム非依存 API (`getSerializableSnapshot()` / `setupSnapshotFromSerializedData()`) をラップし、ファイル I/O 部分を担います。

## 追加 API (`promidas-utils/repository`)

- `exportSnapshotToFile(repository, filePath, options?)` — スナップショットを JSON ファイルへ書き出し
- `importSnapshotFromFile(repository, filePath)` — JSON ファイルからスナップショットを復元
- Result / エラー型: `FileExportResult` / `FileImportResult` / `FileIoError` ほか

## 設計のポイント

- **例外を投げない**: すべて判別可能ユニオン (`ok: true | false`) で返す
- **ディレクトリ自動作成** + **アトミック書き込み** (一意な一時ファイル → `rename`)
- **エラー分類**: `FileIoError.kind` (SERIALIZE/WRITE/READ/PARSE/SETUP_FAILED) + Node の `code` + `cause`
- **既存資産の再利用**: import の検証失敗時は promidas の `SnapshotOperationFailure` を保持し、既存 `toLocalizedMessage()` で日本語化可能
- 引数は `Pick<>` で必要メソッドのみ受け、依存を明示・スタブを容易化

## テスト

- 単体 (スタブ): ファイル I/O ロジック、pretty 整形、各エラー分類、tmp 残存なし
- 統合 (実リポジトリ): import 前 0 件 → import 後に件数変化 → `getStats()` / `getRandomPrototypeFromSnapshot()` で参照可能 → export/再 import の往復整合

全 216 テスト緑、カバレッジ 100%、lint / format / typecheck / build すべてパス。

## その他

- `RELEASE.md` を修正 (無効化済み GitHub Packages ワークフロー参照 → npmjs Trusted Publishing へ)。Issue #8 とは別種の小修正のため別コミットに分離しています。

## 補足

- バージョン bump はこの PR に含めません (マージ後にリリース工程で MINOR 3.1.0 として実施予定)
- CHANGELOG は `[Unreleased]` に追記済み

Refs: #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)