### PR TITLE
chore(release): 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-07-07
+
 ### Added
 
 - **ユーティリティ**: ProtoPedia のユーザー名文字列を分解する `parseUsername` を追加 (#42)
@@ -146,7 +148,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API documentation with per-path reference pages
 - Release guide and changelog
 
-[Unreleased]: https://github.com/F88/promidas-utils/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/F88/promidas-utils/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/F88/promidas-utils/releases/tag/v3.2.0
 [3.1.0]: https://github.com/F88/promidas-utils/releases/tag/v3.1.0
 [3.0.0]: https://github.com/F88/promidas-utils/releases/tag/v3.0.0
 [2.0.0]: https://github.com/F88/promidas-utils/releases/tag/v2.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promidas-utils",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promidas-utils",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/eslint": "^9.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promidas-utils",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Utilities to assist development using PROMIDAS",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
Release **3.2.0** (MINOR).

## Included

### Added
- **`parseUsername`** (`promidas-utils/utils`) — decodes a ProtoPedia username
  (`displayName@profileId`) into `{ displayName, profileId }` via a last-`@`
  split. Best-effort: a username whose real `profileId` contains `@` cannot be
  decoded correctly (documented limitation). (#42, PR #44)

### Dev / maintenance (not user-facing)
- `@typescript-eslint/*` → 8.63.0, `promidas` devDependency → ^3.0.1 (PR #45).
  peerDependencies stays `>=3.0.0`.

## Release mechanics
- Version bumped with `npm version minor --no-git-tag-version` only (no
  `npm install` — it would prune cross-platform lockfile entries). Lockfile diff
  is version fields only.

After merge: tag `v3.2.0` and publish a GitHub Release (triggers the npm publish
workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)